### PR TITLE
fix: get_user_threads function

### DIFF
--- a/threads_api/src/threads_api.py
+++ b/threads_api/src/threads_api.py
@@ -311,7 +311,7 @@ class ThreadsAPI:
                         'userID': user_id,
                     }
                 ),
-                'doc_id': '6307072669391286'
+                'doc_id': '6232751443445612'
             }
         
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
### Issue

`get_user_threads` function show the same result that `get_user_reply`'s function.

### Solution

The `doc_id` variable was the same for `get_user_reply`'s and `get_user_threads`, now have the correct id's each function and display their related threads. As #22 MSLolita mentioned.