### PR TITLE
Update threads_api.py

### DIFF
--- a/example.py
+++ b/example.py
@@ -6,6 +6,24 @@ from threads_api.src.http_sessions.instagrapi_session import InstagrapiSession
 from threads_api.src.http_sessions.requests_session import RequestsSession
 from threads_api.src.http_sessions.aiohttp_session import AioHTTPSession
 
+
+async def example():
+    api = ThreadsAPI(username="...", password="...", cached_token_path=".token")
+
+    username = "zuck"
+    
+    # async with statement starts a context manager, which is used as a shortcut for login, executing and closing.
+    async with api as client:
+        user_id = await client.get_user_id_from_username(username)
+    print(f"The user ID for username '{username}' is: {user_id}") if user_id else print(f"User ID not found for username '{username}'")
+
+    # instead of using the context manager
+    await api.login() # or await api.start()
+    user_id = await client.get_user_id_from_username(username)
+    print(f"The user ID for username '{username}' is: {user_id}") if user_id else print(f"User ID not found for username '{username}'")
+
+    await api.close_gracefully() # close http and clear.
+
 # Asynchronously gets the user ID from a username
 async def get_user_id_from_username():
     api = ThreadsAPI()

--- a/threads_api/src/threads_api.py
+++ b/threads_api/src/threads_api.py
@@ -157,7 +157,8 @@ class ThreadsAPI:
             settings=self._settings.get_settings())
 
     async def __aenter__(self):
-        return await self.login()
+        await self.login()
+        return self
 
     async def __aexit__(self, *args):
         try:
@@ -219,7 +220,7 @@ class ThreadsAPI:
                                                 not using cache.
                                                 
         Returns:
-            :obj:`~ThreadsAPI`: The logged-in client itself.
+            bool: True if the login is successful, False otherwise.
 
         Raises:
             Exception: If the username or password are invalid, or if an error occurs during login.
@@ -280,7 +281,7 @@ class ThreadsAPI:
             try:
                 self._auth_session = self.http_session_class()
                 await _set_logged_in_state(username, _get_token_from_cache(cached_token_path, password))
-                return self
+                return True
             except LoggedOutException as e:
                 print(f"[Error] {e}. Attempting to re-login.")
                 pass
@@ -303,8 +304,9 @@ class ThreadsAPI:
             print("[ERROR] ", e)
             raise
 
-        return self
+        return True
 
+    # an alias for the login function.
     start = login
 
     async def close_gracefully(self):

--- a/threads_api/src/threads_api.py
+++ b/threads_api/src/threads_api.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Dict, Union, List
+from typing import Any, Callable, Optional, Dict, Union, List
 import aiohttp
 import re
 import json
@@ -107,6 +107,11 @@ def require_login(func):
             raise Exception(f"The action '{func.__name__}' can only be perfomed while logged-in")
         return await func(self, *args, **kwargs)
     return wrapper
+
+async def run_sync(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, functools.partial(func, *args, **kwargs))
+
 
 class ThreadsAPI:
     def __init__(
@@ -255,10 +260,10 @@ class ThreadsAPI:
             return
         
         if not (username := username or self.username):
-            username = input("Please enter your Instagram username: ")
+            username = await run_sync(input, "Please enter your Instagram username: ")
 
         if not (password := password or self.password):
-            password = getpass("Please enter your Instagram password: ")
+            password = await run_sync(getpass, "Please enter your Instagram password: ")
 
         if not (username and password):
             raise Exception("No username or password provided.")


### PR DESCRIPTION
Allowed specifying username, password, and cached_token_path in both class init and login methods

Promted when username and password not provider, instead of immediately raising

Add async context manager for login and closing